### PR TITLE
Bump circe to 0.10-M1 and iteratee to 0.18

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,8 @@ val compilerOptions = Seq(
   "-Xfuture"
 )
 
-val circeVersion = "0.9.0"
-val iterateeVersion = "0.17.0"
+val circeVersion = "0.10.0-M1"
+val iterateeVersion = "0.18.0"
 val previousCirceIterateeVersion = "0.8.0"
 
 val baseSettings = Seq(


### PR DESCRIPTION
I was thinking to make a new Finch release against Circe 0.10-M1 (as it's the only way to unify on Cats 1.1.0). NOTE: this is pending Iteratee release (0.18) against Cats 1.1.0.